### PR TITLE
fix: 친구 도메인 논리적 오류 해결, 변수명 수정

### DIFF
--- a/src/main/java/inxj/newsfeed/friend/controller/FriendController.java
+++ b/src/main/java/inxj/newsfeed/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package inxj.newsfeed.friend.controller;
 
 import inxj.newsfeed.friend.dto.FriendRequestResponseDto;
+import inxj.newsfeed.friend.dto.FriendRequestWithStatusResponseDto;
 import inxj.newsfeed.friend.dto.FriendResponseDto;
 import inxj.newsfeed.friend.service.FriendService;
 import jakarta.servlet.http.HttpSession;
@@ -29,40 +30,40 @@ public class FriendController {
     /*
     친구 삭제 API
      */
-    @DeleteMapping("/friends/{friendId}")
-    public ResponseEntity<Void> deleteFriend(HttpSession session, @PathVariable Long friendId){
+    @DeleteMapping("/friends/{targetId}")
+    public ResponseEntity<Void> deleteFriend(HttpSession session, @PathVariable Long targetId){
         Long loginUserId = (Long) session.getAttribute("loginUser");
-        friendService.deleteFriend(loginUserId, friendId);
+        friendService.deleteFriend(loginUserId, targetId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     /*
     친구 요청 API
      */
-    @PostMapping("/friend-requests/{userId}")
-    public ResponseEntity<Void> requestFriend(HttpSession session, @PathVariable Long userId){
+    @PostMapping("/friend-requests/{targetId}")
+    public ResponseEntity<Void> requestFriend(HttpSession session, @PathVariable Long targetId){
         Long loginUserId = (Long) session.getAttribute("loginUser");
-        friendService.requestFriend(loginUserId, userId);
+        friendService.requestFriend(loginUserId, targetId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     /*
     친구 요청 수락 API
      */
-    @PostMapping("/friend-requests/accept/{userId}")
-    public ResponseEntity<Void> acceptRequest(HttpSession session, @PathVariable Long userId){
+    @PostMapping("/friend-requests/accept/{targetId}")
+    public ResponseEntity<Void> acceptRequest(HttpSession session, @PathVariable Long targetId){
         Long loginUserId = (Long) session.getAttribute("loginUser");
-        friendService.acceptRequest(loginUserId, userId);
+        friendService.acceptRequest(loginUserId, targetId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     /*
     친구 요청 거절 API
      */
-    @PostMapping("/friend-requests/reject/{userId}")
-    public ResponseEntity<Void> rejectRequest(HttpSession session, @PathVariable Long userId){
+    @PostMapping("/friend-requests/reject/{targetId}")
+    public ResponseEntity<Void> rejectRequest(HttpSession session, @PathVariable Long targetId){
         Long loginUserId = (Long) session.getAttribute("loginUser");
-        friendService.rejectRequest(loginUserId, userId);
+        friendService.rejectRequest(loginUserId, targetId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
@@ -70,7 +71,7 @@ public class FriendController {
     보낸 친구 요청 목록 조회 API
      */
     @GetMapping("/friend-requests/sent")
-    public ResponseEntity<List<FriendRequestResponseDto>> findSentRequests(HttpSession session){
+    public ResponseEntity<List<FriendRequestWithStatusResponseDto>> findSentRequests(HttpSession session){
         Long userId = (Long) session.getAttribute("loginUser");
         return new ResponseEntity<>(friendService.findSentRequests(userId), HttpStatus.OK);
     }

--- a/src/main/java/inxj/newsfeed/friend/dto/FriendRequestWithStatusResponseDto.java
+++ b/src/main/java/inxj/newsfeed/friend/dto/FriendRequestWithStatusResponseDto.java
@@ -1,12 +1,14 @@
 package inxj.newsfeed.friend.dto;
 
+import inxj.newsfeed.friend.entity.Status;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class FriendRequestResponseDto {
+public class FriendRequestWithStatusResponseDto {
     private String username;
     private String name;
     private String profileImageUrl;
+    private Status status;
 }

--- a/src/main/java/inxj/newsfeed/friend/repository/FriendRepository.java
+++ b/src/main/java/inxj/newsfeed/friend/repository/FriendRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,7 +23,7 @@ public interface FriendRepository extends JpaRepository<FriendRequest, Long> {
 
     Optional<FriendRequest> findByReceiverAndRequester(User receiver, User requester);
 
-    List<FriendRequest> findByRequester(User requester);
+    List<FriendRequest> findByRequesterAndStatusIn(User requester, Collection<Status> statuses);
 
-    List<FriendRequest> findByReceiver(User receiver);
+    List<FriendRequest> findByReceiverAndStatus(User user, Status status);
 }


### PR DESCRIPTION
- 친구 요청을 했을 때, 상대방이 나에게 요청한 상태면 ACCEPT로 변경
- 본인에게 친구 요청 시 예외처리
- 받은 친구 요청 목록에서 Status = PENDING만 반환
- 보낸 친구 요청 목록에서 Status == PENDING && Status == REJECT만 반환
- 보낸 친구 요청 목록 조회 시, Status도 같이 반환
- 상대방 변수를 userId에서 targetId로 직관적으로 변경